### PR TITLE
Make Service::call() take &mut self

### DIFF
--- a/examples/expect-continue.rs
+++ b/examples/expect-continue.rs
@@ -12,7 +12,7 @@ impl Service for UploadService {
     type Body = &'static str;
     type Error = Infallible;
 
-    fn call(&self, _req: Request<Body>) -> Result<http::Response<Self::Body>, Self::Error> {
+    fn call(&mut self, _req: Request<Body>) -> Result<http::Response<Self::Body>, Self::Error> {
         Ok(Response::builder()
             .status(StatusCode::OK)
             .body("Thanks for the info!")


### PR DESCRIPTION
I found it useful in a single threaded environment to have the option to use an `FnMut` service.

Example:

```rust
let mut counter = 0;
Server::bind((address, port))
    .serve_single_thread(|_| {
        counter += 1;
        Response::builder().status(200).body(format!("count = {}", counter))
    })
    .unwrap();
```