### PR TITLE
Make threadpool optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ categories = ["network-programming", "web-programming"]
 keywords = ["web", "http", "protocol"]
 
 [features]
-default = ["server"]
+default = ["server", "threadpool"]
 full = ["client", "server"]
-server = ["threadpool"]
+threadpool = ["dep:threadpool"]
+server = []
 unix-sockets = []
 client = []
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -29,6 +29,7 @@ use std::{
 
 use headers::{HeaderMapExt, HeaderValue};
 use http::{Method, Request, Response, StatusCode, Version};
+#[cfg(feature = "threadpool")]
 use threadpool::ThreadPool;
 
 use crate::{
@@ -118,6 +119,7 @@ where
 
 /// A listening HTTP server that accepts HTTP 1 connections.
 pub struct Server<'a> {
+    #[cfg(feature = "threadpool")]
     thread_pool: ThreadPool,
     incoming: Box<dyn Iterator<Item = Connection> + 'a>,
 }
@@ -157,6 +159,7 @@ impl<'a> Server<'a> {
     /// })
     /// # }
     /// ```
+    #[cfg(feature = "threadpool")]
     pub fn serve<S>(self, service: S) -> io::Result<()>
     where
         S: Service,
@@ -219,6 +222,7 @@ impl<'a> Server<'a> {
     ///     })
     /// # }
     /// ```
+    #[cfg(feature = "threadpool")]
     pub fn make_service<M>(self, make_service: M) -> io::Result<()>
     where
         M: MakeService,
@@ -239,6 +243,7 @@ impl<'a> Server<'a> {
 }
 
 pub struct ServerBuilder {
+    #[cfg(feature = "threadpool")]
     max_threads: usize,
     read_timeout: Option<Duration>,
 }
@@ -246,6 +251,7 @@ pub struct ServerBuilder {
 impl Default for ServerBuilder {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "threadpool")]
             max_threads: 512,
             read_timeout: None,
         }
@@ -269,6 +275,7 @@ impl ServerBuilder {
     ///     })
     /// # }
     /// ```
+    #[cfg(feature = "threadpool")]
     pub fn max_threads(self, max_threads: usize) -> Self {
         Self {
             max_threads,
@@ -362,6 +369,7 @@ impl ServerBuilder {
         conns: T,
     ) -> Server<'a> {
         Server {
+            #[cfg(feature = "threadpool")]
             thread_pool: ThreadPool::new(self.max_threads),
             incoming: Box::new(conns.into_iter().filter_map(move |conn| {
                 conn.set_read_timeout(self.read_timeout).ok()?;


### PR DESCRIPTION
I am using touche in single threaded mode and I was expecting that my config (below) would eliminate the code from threadpool crate if unused, but it was not able to completely remove it. I assume this was because of some use of it in `Server` type.

```toml
[profile.release]
opt-level = "z"
lto = true
codegen-units = 1
```

With this MR, I was able to fully eliminate threadpool crate's code from my final binary.