### PR TITLE
Avoid creating unnecessary thread pool

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -56,7 +56,7 @@ impl BodyChannel {
     pub fn send<T: Into<Vec<u8>>>(&self, data: T) -> io::Result<()> {
         self.0
             .send(Ok(data.into().into()))
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "body closed"))
+            .map_err(|_| io::Error::other("body closed"))
     }
 
     /// Send a trailer header. Note that trailers are buffered, and are only sent after the last
@@ -82,14 +82,12 @@ impl BodyChannel {
     pub fn send_trailers(&self, trailers: HeaderMap) -> io::Result<()> {
         self.0
             .send(Ok(Chunk::Trailers(trailers)))
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "body closed"))
+            .map_err(|_| io::Error::other("body closed"))
     }
 
     /// Aborts the body in an abnormal fashion.
     pub fn abort(self) {
-        self.0
-            .send(Err(io::Error::new(io::ErrorKind::Other, "aborted")))
-            .ok();
+        self.0.send(Err(io::Error::other("aborted"))).ok();
     }
 }
 
@@ -253,7 +251,7 @@ impl TryFrom<File> for Body {
     fn try_from(file: File) -> Result<Self, Self::Error> {
         match file.metadata() {
             Ok(meta) if meta.is_file() => Ok(Body::from_reader(file, meta.len() as usize)),
-            Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "not a file")),
+            Ok(_) => Err(io::Error::other("not a file")),
             Err(err) => Err(err),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,8 +118,7 @@ where
     request::write_request(req, &mut writer)?;
     writer.flush()?;
 
-    let res = response::parse_response(reader)
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+    let res = response::parse_response(reader).map_err(io::Error::other)?;
 
     let asks_for_close = res
         .headers()

--- a/src/request.rs
+++ b/src/request.rs
@@ -140,10 +140,7 @@ pub(crate) fn write_request<B: HttpBody>(
         match (content_length, body.len()) {
             (Some(len), Some(body_len)) => {
                 if len.0 != body_len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "content-length doesn't match body length",
-                    ));
+                    return Err(io::Error::other("content-length doesn't match body length"));
                 }
                 Encoding::FixedLength(len.0)
             }
@@ -162,10 +159,7 @@ pub(crate) fn write_request<B: HttpBody>(
         headers.typed_insert::<headers::TransferEncoding>(headers::TransferEncoding::chunked());
         Encoding::Chunked
     } else {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            "could not determine the size of the body",
-        ));
+        return Err(io::Error::other("could not determine the size of the body"));
     };
 
     let version = if version == Version::HTTP_11 {
@@ -173,10 +167,7 @@ pub(crate) fn write_request<B: HttpBody>(
     } else if version == Version::HTTP_10 {
         "HTTP/1.0"
     } else {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
-            "unsupported http version",
-        ));
+        return Err(io::Error::other("unsupported http version"));
     };
 
     stream.write_all(format!("{method} {uri} {version}\r\n").as_bytes())?;

--- a/src/response.rs
+++ b/src/response.rs
@@ -137,10 +137,7 @@ pub(crate) fn write_response<B: HttpBody>(
         match (content_length, body.len()) {
             (Some(len), Some(body_len)) => {
                 if len.0 != body_len {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "content-length doesn't match body length",
-                    ));
+                    return Err(io::Error::other("content-length doesn't match body length"));
                 }
                 Encoding::FixedLength(len.0)
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -507,9 +507,7 @@ fn serve<A: Service>(conn: Connection, app: &mut A) -> io::Result<()> {
                     };
                 }
 
-                let mut res = app
-                    .call(req)
-                    .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+                let mut res = app.call(req).map_err(io::Error::other)?;
 
                 *res.version_mut() = version;
 
@@ -542,7 +540,7 @@ fn serve<A: Service>(conn: Connection, app: &mut A) -> io::Result<()> {
                 }
             }
             Err(ParseError::ConnectionClosed) => break,
-            Err(err) => return Err(io::Error::new(io::ErrorKind::Other, err)),
+            Err(err) => return Err(io::Error::other(err)),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -120,7 +120,7 @@ where
 /// A listening HTTP server that accepts HTTP 1 connections.
 pub struct Server<'a> {
     #[cfg(feature = "threadpool")]
-    thread_pool: ThreadPool,
+    max_threads: usize,
     incoming: Box<dyn Iterator<Item = Connection> + 'a>,
 }
 
@@ -165,9 +165,10 @@ impl Server<'_> {
         S: Service,
         S: Send + Clone + 'static,
     {
+        let thread_pool = ThreadPool::new(self.max_threads);
         for conn in self.incoming {
             let mut app = service.clone();
-            self.thread_pool.execute(move || {
+            thread_pool.execute(move || {
                 serve(conn, &mut app).ok();
             });
         }
@@ -253,9 +254,10 @@ impl Server<'_> {
         M: MakeService + 'static,
         <M as MakeService>::Service: Send,
     {
+        let thread_pool = ThreadPool::new(self.max_threads);
         for conn in self.incoming {
             if let Ok(mut handler) = make_service.call(&conn) {
-                self.thread_pool.execute(move || {
+                thread_pool.execute(move || {
                     serve(conn, &mut handler).ok();
                 });
             }
@@ -407,7 +409,7 @@ impl ServerBuilder {
     ) -> Server<'a> {
         Server {
             #[cfg(feature = "threadpool")]
-            thread_pool: ThreadPool::new(self.max_threads),
+            max_threads: self.max_threads,
             incoming: Box::new(conns.into_iter().filter_map(move |conn| {
                 let conn = conn.into();
                 conn.set_read_timeout(self.read_timeout).ok()?;

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -41,7 +41,7 @@ impl RustlsConnection {
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.0
             .lock()
-            .map_err(|_err| io::Error::new(io::ErrorKind::Other, "Failed to aquire lock"))?
+            .map_err(|_err| io::Error::other("Failed to aquire lock"))?
             .sock
             .peer_addr()
     }
@@ -49,7 +49,7 @@ impl RustlsConnection {
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.0
             .lock()
-            .map_err(|_err| io::Error::new(io::ErrorKind::Other, "Failed to aquire lock"))?
+            .map_err(|_err| io::Error::other("Failed to aquire lock"))?
             .sock
             .local_addr()
     }
@@ -59,7 +59,7 @@ impl Read for RustlsConnection {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.0
             .lock()
-            .map_err(|_err| io::Error::new(io::ErrorKind::Other, "Failed to aquire lock"))?
+            .map_err(|_err| io::Error::other("Failed to aquire lock"))?
             .read(buf)
     }
 }
@@ -68,14 +68,14 @@ impl Write for RustlsConnection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0
             .lock()
-            .map_err(|_err| io::Error::new(io::ErrorKind::Other, "Failed to aquire lock"))?
+            .map_err(|_err| io::Error::other("Failed to aquire lock"))?
             .write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         self.0
             .lock()
-            .map_err(|_err| io::Error::new(io::ErrorKind::Other, "Failed to aquire lock"))?
+            .map_err(|_err| io::Error::other("Failed to aquire lock"))?
             .flush()
     }
 }


### PR DESCRIPTION
Unless the `threadpool` feature is disabled, `Server` always contains a thread pool, even if it is unnecessary because the `Server` is only used with `serve_single_thread`. Fix this by deferring creating the thread pool until it is actually required.

I noticed this because I was getting resource exhaustion errors when running a single-threaded server in a podman container, which restricts the number of threads. Disabling the `threadpool` feature also fixes this, but this must be done explicitly since it's a default feature.

Also:

Fix clippy warnings about replacing `io::Error::new(io::ErrorKind::Other, ...)` with `io::Error::other(...)`.